### PR TITLE
Multi-Login Grundfunktion

### DIFF
--- a/assets/js/ycom_fast_forward_multilogin.js
+++ b/assets/js/ycom_fast_forward_multilogin.js
@@ -1,0 +1,34 @@
+fetch('/?rex-api-call=ycom_fast_forward_multi_login&init=1')
+.then(response => response.json())
+.then(data => {
+    const domains = Object.keys(data);
+
+
+    // Execute the function with the fetched domains
+    loginToDomains(domains, token);
+})
+.catch(error => {
+    console.error('Error fetching domains:', error);
+});
+
+// Function to log in to each domain
+function loginToDomains(domains, token) {
+    domains.forEach(domain => {
+        const url = `https://${domain}/?rex-api-call=ycom_fast_forward_multi_login&token=${token}`;
+        
+        fetch(url, {
+            method: 'GET',
+            credentials: 'include'
+        })
+        .then(response => {
+            if (response.ok) {
+                console.log(`Logged in to ${domain} successfully.`);
+            } else {
+                console.error(`Failed to log in to ${domain}.`);
+            }
+        })
+        .catch(error => {
+            console.error(`Error logging in to ${domain}:`, error);
+        });
+    });
+}

--- a/boot.php
+++ b/boot.php
@@ -1,7 +1,7 @@
 <?php
 
 use Alexplusde\YComFastForward\ActivationKey;
-
+use Alexplusde\YComFastForward\Api\MultiLogin;
 /** @var rex_addon $this */
 
 if (rex::isBackend()) {
@@ -21,3 +21,5 @@ if (rex_addon::get('yform')->isAvailable() && !rex::isSafeMode()) {
 		ActivationKey::class, // Hier anpassen, falls Namespace verwendet wird
 	);
 }
+
+rex_api_function::register('ycom_fast_forward_multi_login', MultiLogin::class);

--- a/lib/Api/MultiLogin.php
+++ b/lib/Api/MultiLogin.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Alexplusde\YComFastForward\Api;
+
+use Alexplusde\YComFastForward\ActivationKey;
+
+use rex_api_function;
+use rex_response;
+use rex_yrewrite;
+
+class MultiLogin extends rex_api_function
+{
+
+    const url = '/index.php?rex-api-call=ycom_fast_forward_multi_login&token=XXX';
+
+    public function execute()
+    {
+        header('Content-Type: application/json; charset=UTF-8');
+        $ycom_user = \rex_ycom_auth::getUser();
+        // Wenn get-Paramter "init" gesetzt ist, dann alle Domains mit allen Token als JSON ausgeben
+        if ($ycom_user !== null && rex_request('init', 'int', 0) === 1) {
+            $domains = rex_yrewrite::getDomains();
+            $response = [];
+            foreach ($domains as $domain) {
+                $response[$domain] = ActivationKey::new($ycom_user->getId());
+            }
+            rex_response::setStatus(rex_response::HTTP_OK);
+            echo json_encode($response);
+            exit;
+        }
+
+
+        $token = rex_request('token', 'string', '');
+
+        if (!$token) {
+            rex_response::setStatus(rex_response::HTTP_FORBIDDEN);
+            echo json_encode(['status' => 403, 'message' => 'Forbidden']);
+            exit;
+        }
+
+        // Wenn bereits eingeloggt, dann ist die Aktion unnötig
+        if ($ycom_user !== null) {
+            rex_response::setStatus(rex_response::HTTP_OK);
+            echo json_encode(['status' => 200, 'message' => 'Already logged in']);
+            exit;
+        }
+
+        $activationKey = ActivationKey::findByKey($token);
+
+        if (!$activationKey || !$activationKey->isActive()) {
+            rex_response::setStatus(rex_response::HTTP_FORBIDDEN);
+            echo json_encode(['status' => 403, 'message' => 'Forbidden']);
+            exit;
+        }
+
+        if ($activationKey->login()) {
+            $activationKey->setStatusExpired();
+            rex_response::setStatus(rex_response::HTTP_OK);
+            echo json_encode(['status' => 200, 'message' => 'Login successful']);
+            exit;
+        }
+
+        rex_response::setStatus(rex_response::HTTP_FORBIDDEN);
+        echo json_encode(['status' => 403, 'message' => 'Forbidden']);
+        exit;
+    }
+
+}

--- a/pages/ycom.fast_forward.settings.php
+++ b/pages/ycom.fast_forward.settings.php
@@ -123,6 +123,16 @@ $field = $form->addTextField('editor', null, ['class' => 'form-control']);
 $field->setLabel(rex_i18n::msg('ycom_fast_forward.config.editor'));
 $field->setNotice(rex_i18n::msg('ycom_fast_forward.config.editor.notice'));
 
+/* Fieldset für Multi-Access */
+
+$field = $form->addSelectField('enable_multidomain', null, ['class' => 'form-control']);
+$field->setLabel(rex_i18n::msg('ycom_fast_forward.config.enable_multidomain'));
+$field->setNotice(rex_i18n::msg('ycom_fast_forward.config.enable_multidomain.notice'));
+
+$select = $field->getSelect();
+$select->setSize(1);
+$select->addOption(rex_i18n::msg('ycom_fast_forward.config.enable_multidomain.no'), '0');
+$select->addOption(rex_i18n::msg('ycom_fast_forward.config.enable_multidomain.yes'), '1');
 
 // Formular ausgeben mit Core Section Fragment */
 


### PR DESCRIPTION
Ermöglicht innerhalb einer REDAXO-Installation mit mehreren Domains das ad-hoc Erstellen von Login-Token und einem JavaScript zum Abruf der Token sowie einer API zum Einloggen.