### PR TITLE
SQL-Fehler SQLSTATE[HY093]: Invalid parameter number: parameter was not defined in setYcomAuthForArticle-Funktion

### DIFF
--- a/install.php
+++ b/install.php
@@ -17,6 +17,7 @@ if ($module->getRows() === 0) {
     rex_sql::factory()
         ->setTable(rex::getTablePrefix() . 'module')
         ->setValue('name', 'translate:ycom_fast_forward.module.name')
+        ->setValue('key', 'ycom_fast_forward')
         ->setValue('input', $input)
         ->setValue('output', $output)
         ->setValue('createuser', 'ycom_fast_forward')

--- a/lib/YComFastForward.php
+++ b/lib/YComFastForward.php
@@ -49,7 +49,7 @@ class YComFastForward
     public static function setYcomAuthForArticle(int $article_id, int $auth_type = 0): void
     {
         \rex_sql::factory()->setTable(\rex::getTable('article'))
-            ->setWhere('id = :pid', ['id' => $article_id])
+            ->setWhere('id = :pid', ['pid' => $article_id])
             ->setValue('ycom_auth_type', $auth_type)
             ->update();
     }


### PR DESCRIPTION
Parametername in der setWhere-Methode nicht korrekt